### PR TITLE
Add import-zone action to import zone files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ positional arguments:
                         port, protocol and subname
     export              export all records into a file
     import              import records from a file
+    import-zone         import records from a zone file
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/desec-dns.py
+++ b/desec-dns.py
@@ -890,6 +890,7 @@ def main():
                     (?P<type>[A-Z0-9]+)\s+
                     (?P<record>.*)$''',
                     re.VERBOSE)
+                minimum_ttl = api_client.domain_info(arguments.domain)['minimum_ttl']
 
                 # Parse the zone file into a (temporary) dict.
                 record_dict = {}
@@ -910,10 +911,10 @@ def main():
                         print(f'Record type {rtype} not supported, skipping...', file=sys.stderr)
                         continue
 
-                    if ttl < 3600:
-                        print('TTL smaller than minimum of 3600 seconds, adjusting.',
+                    if ttl < minimum_ttl:
+                        print(f'TTL smaller than minimum of {minimum_ttl} seconds, adjusting.',
                               file=sys.stderr)
-                        ttl = 3600
+                        ttl = minimum_ttl
 
                     records = sanitize_records(rtype, subname, [record])
 

--- a/desec-dns.py
+++ b/desec-dns.py
@@ -347,11 +347,11 @@ class APIClient(object):
         if code == 200:
             return data
         elif code == 400:
-            raise APIError('Could not create RRsets. Errors: {}'.format(data))
+            raise APIError(f'Could not create RRsets. Errors: {data}')
         elif code == 404:
-            raise NotFoundError('Domain {} not found'.format(domain))
+            raise NotFoundError(f'Domain {domain} not found')
         else:
-            raise APIError('Unexpected error code {}'.format(code))
+            raise APIError(f'Unexpected error code {code}')
 
     def change_record(self, domain, rtype, subname, rrset=None, ttl=None):
         """Change an existing RRset. Existing data is replaced by the provided `rrset` and `ttl`


### PR DESCRIPTION
This adds a new `import-zone` action that can be used to migrate from other DNS providers to Desec using a zone file.

The code has been successfully tested with three zones.