### PR TITLE
Add types-requests as dev dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ desec = "desec:main"
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.4.5"
 mypy = ">=1.10.0"
+types-requests = ">=2.32.0.20240602"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Since we allow installing our python "dev tooling" via `poetry install --with=dev`, it should probably be as complete as possible. `types-requests` is needed to successfully run `mypy`. 