### PR TITLE
Drop assert in APIClient.parse_links()

### DIFF
--- a/desec.py
+++ b/desec.py
@@ -632,7 +632,6 @@ class APIClient:
                 raise APIExpectationError("Unexpected format in Link header")
             label = m.group(1)
             _url = _url[1:-1]
-            assert label not in mapping
             mapping[label] = _url
         return mapping
 


### PR DESCRIPTION
It is removed from optimized code anyway and only ever triggers if the API behaves differently from what's currently documented.