### PR TITLE
Fix: domain positional arg being eaten by previous args

### DIFF
--- a/desec.py
+++ b/desec.py
@@ -1686,7 +1686,7 @@ def _main() -> None:
         "-r",
         "--records",
         required=True,
-        nargs="+",
+        action="append",
         metavar="RECORD",
         help="the DNS record(s) to add",
     )
@@ -1710,7 +1710,9 @@ def _main() -> None:
         default="",
         help="subname to change, omit to change a record in the zone apex",
     )
-    p.add_argument("-r", "--records", nargs="+", metavar="RECORD", help="the new DNS record(s)")
+    p.add_argument(
+        "-r", "--records", action="append", metavar="RECORD", help="the new DNS record(s)"
+    )
     p.add_argument("--ttl", type=int, help="the new TTL")
 
     p = p_action.add_parser("delete-record", help="delete a record set")
@@ -1732,7 +1734,7 @@ def _main() -> None:
     p.add_argument(
         "-r",
         "--records",
-        nargs="+",
+        action="append",
         metavar="RECORD",
         help="the DNS records to delete (default: all)",
     )
@@ -1755,7 +1757,7 @@ def _main() -> None:
     p.add_argument(
         "-r",
         "--records",
-        nargs="+",
+        action="append",
         required=True,
         metavar="RECORD",
         help="the DNS records to add",
@@ -1781,7 +1783,7 @@ def _main() -> None:
             help="subname that the record is valid for, omit to set a record to the zone apex",
         )
         p.add_argument(
-            "-p", "--ports", nargs="+", required=True, help="ports that use the certificate"
+            "-p", "--ports", action="append", required=True, help="ports that use the certificate"
         )
         p.add_argument(
             "--protocol",
@@ -1853,7 +1855,7 @@ def _main() -> None:
             help="subname that the record is valid for, omit to set a record to the zone apex",
         )
         p.add_argument(
-            "-p", "--ports", nargs="+", required=True, help="ports that use the certificate"
+            "-p", "--ports", action="append", required=True, help="ports that use the certificate"
         )
         p.add_argument(
             "--protocol",


### PR DESCRIPTION
For single-minded people like me the usage can be tricky.

The help for `add-record` and others can be misleading:

```bash
desec add-record -h
usage: desec add-record [-h] -t TYPE [-s SUBNAME] -r RECORD [RECORD ...] [--ttl TTL] domain

positional arguments:
  domain                domain name

options:
  -h, --help            show this help message and exit
  -t TYPE, --type TYPE  record type to add
  -s SUBNAME, --subname SUBNAME
                        subname to add, omit to add a record to the zone apex
  -r RECORD [RECORD ...], --records RECORD [RECORD ...]
                        the DNS record(s) to add
  --ttl TTL             set the record's TTL (default: 3600 seconds)
```

So I gave it a try:

```bash
desec add-record -t A -s www -r 1.2.3.4 example.com
usage: desec add-record [-h] -t TYPE [-s SUBNAME] -r RECORD [RECORD ...] [--ttl TTL] domain
desec add-record: error: the following arguments are required: domain
```

🤔

After some investigation it showed that `domain` can't be used after `-r 1.2.3.4`. argparse considers the domain `example.com` as another record because `-r`/`--records` uses `nargs="+"`.

`domain` has to be given before `-r`/`--records`:

```bash
desec add-record -t A -s www example.com -r 1.2.3.4
```

This doesn't seem to be very intuitive. So I would suggest to use `action="append"` with these arguments. This way `domain` can be used as the last argument. But dashed arguments have to be repeated though:

```bash
desec add-record -t A -s www -r 1.2.3.4 -r 5.6.7.8 example.com
```