### PR TITLE
Do not include CHANGELOG.md in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 packages = [{ include = "desec.py" }]
-include = ["CHANGELOG.md"]
+include = [
+    { path = "CHANGELOG.md", format = "sdist" },
+]
 
 [tool.poetry.urls]
 "Issue Tracker" = "https://github.com/s-hamann/desec-dns/issues"


### PR DESCRIPTION
This keeps CHANGELOG.md from getting installed to the site-packages directory.