### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -46,7 +46,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The features include:
 Requirements
 ============
 
-* Python 3.9+
+* Python 3.10+
 * [requests](https://github.com/requests/requests)
 * [cryptography](https://github.com/pyca/cryptography/) (optional, for high-level
   management of TLSA records)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 Changelog = "https://github.com/s-hamann/desec-dns/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 requests = ">=2.0.0"
 cryptography = { version = ">=42.0.0", optional = true }
 dnspython = { version = ">=2.0.0", optional = true }
@@ -51,7 +51,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 line-length = 99
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 extend-select = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0.0
-envlist = py39, py310, py311, py312, py313, py314, pypy3, coverage
+envlist = py310, py311, py312, py313, py314, pypy3, coverage
 skip_missing_interpreters = true
 
 [gh]
@@ -10,7 +10,6 @@ python =
     3.12 = py312
     3.11 = py311
     3.10 = py310
-    3.9 = py39
     pypy-3.9 = pypy3
 
 [testenv]
@@ -34,7 +33,7 @@ package = editable
 [testenv:coverage]
 description = combine test coverage results and generate reports
 skip_install = true
-depends = py39, py310, py311, py312, py313, py314, pypy3
+depends = py310, py311, py312, py313, py314, pypy3
 deps =
     coverage
 commands_pre =


### PR DESCRIPTION
Python 3.9 has reached end-of-life, so we drop support for it. The code may or may not continue to work on Python 3.9.