### PR TITLE
Read auth token from environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage.lcov
 coverage.xml
 htmlcov/
 poetry.lock
+**/__pycache__/
+dist/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Usage
 
 ### CLI
 
+The deSEC API requires an token for authentication, which you can create on the
+[deSEC.io](https://desec.io/) website or through the API if you already have another token. You can
+provide this token to the CLI:
+
+1. Via the `--token` argument
+2. In the `DESEC_TOKEN` environment variable
+3. In a file by passing a path to the `--token-file` argument
+4. In a file at `$XDG_CONFIG_HOME/desec/token`
+
+In case multiple methods are used simultaneously, priority will be given according to the list
+above in order.
+
 The functionality is split into subcommands, as shown below.
 Most subcommand require further parameters to work.
 They are described by the usage information of each individual subcommand.
@@ -82,7 +94,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
-  --token TOKEN         API authentication token
+  --token TOKEN         API authentication token (default: $DESEC_TOKEN environment variable)
   --token-file TOKEN_FILE
                         file containing the API authentication token (default:
                         $XDG_CONFIG_HOME/desec/token)

--- a/desec/cli.py
+++ b/desec/cli.py
@@ -110,7 +110,11 @@ def main() -> None:
     p_action.required = True
 
     g = parser.add_mutually_exclusive_group()
-    g.add_argument("--token", help="API authentication token")
+    g.add_argument(
+        "--token",
+        default=os.environ.get("DESEC_TOKEN"),
+        help="API authentication token (default: $DESEC_TOKEN environment variable)",
+    )
     g.add_argument(
         "--token-file",
         default=os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"), "desec", "token"),

--- a/tests/test_token_policy.py
+++ b/tests/test_token_policy.py
@@ -73,11 +73,9 @@ def test_add_token_policy_conflict(api_client, domain, new_token):
 @pytest.mark.parametrize("policy_rtype", [False, None, "AAAA"], ids=["keep", None, "AAAA"])
 @pytest.mark.parametrize("policy_perm_write", [None, True, False], ids=["keep", True, False])
 @pytest.mark.uncollect_if(
-    lambda policy_domain,
-    policy_subname,
-    policy_rtype,
-    policy_perm_write,
-    **kwargs: not policy_domain and policy_subname is None and policy_rtype is None
+    lambda policy_domain, policy_subname, policy_rtype, policy_perm_write, **kwargs: (
+        not policy_domain and policy_subname is None and policy_rtype is None
+    )
 )
 def test_modify_token_policy(
     api_client, domain, new_token, policy_domain, policy_subname, policy_rtype, policy_perm_write


### PR DESCRIPTION
Fixes #16 (Partially)

Uses the `DESEC_TOKEN` environment variable as the API auth token. If multiple means of passing in the token are used concurrently then the code will take the value in this order:

1. The `--token` argument
2. The `DESEC_TOKEN` environment variable
3. The value within `--token-file` (default path or no)

FYI: I also add `dist` and `__pycache__` dirs to the .gitignore, and fixed formatting in a test in this PR.