### PR TITLE
Bump Codecov action to latest version

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -99,9 +99,7 @@ jobs:
           name: coverage-report
           path: htmlcov/
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v6
       - name: Report coverage
         run: |
           python >> "${GITHUB_STEP_SUMMARY}" << EOC


### PR DESCRIPTION
Also, remove the Codecov token as it is no longer required to upload coverage data.