### PR TITLE
add support for ignoring ssl warnings

### DIFF
--- a/desec/api.py
+++ b/desec/api.py
@@ -51,6 +51,8 @@ class APIClient:
             Set to 0 to disable.
         logger: Logger instance to send HTTP debug information to. Defaults to the named
             logger `desec.client`.
+        verify: Whether to verify SSL certificates. Set to `False` to disable SSL
+            verification (useful for testing with self-signed certificates).
 
     """
 
@@ -60,11 +62,13 @@ class APIClient:
         request_timeout: int | None = 15,
         retry_limit: int = 3,
         logger: logging.Logger = logging.getLogger("desec.client"),  # noqa: B008
+        verify: bool = True,
     ):
         self._token_auth = TokenAuth(token)
         self._request_timeout = request_timeout
         self._retry_limit = retry_limit
         self.logger = logger
+        self._verify = verify
         "Logger instance to send HTTP debug information to."
 
     @staticmethod
@@ -194,6 +198,7 @@ class APIClient:
                     params=params,
                     json=body,
                     timeout=self._request_timeout,
+                    verify=self._verify,
                 )
                 self.logger.debug(
                     f"Response: {r.status_code} for {method} {url}",

--- a/desec/cli.py
+++ b/desec/cli.py
@@ -609,6 +609,13 @@ def main() -> None:
             action="store_true",
             help="just parse zone data, but do not write it to the API",
         )
+    else:
+        p = p_action.add_parser("import-zone", help="import records from a zone file")
+        p.add_argument("domain", help="domain name")
+        p.add_argument("-f", "--file", required=True, help="target file name")
+        p.add_argument(
+            "--clear", action="store_true", help="remove all existing records before import"
+        )
 
     arguments = parser.parse_args()
     del p_action, g, p, parser
@@ -817,8 +824,17 @@ def main() -> None:
                 f.write(zone_result)
 
         elif arguments.action == "import":
-            with open(arguments.file) as f:
-                records = json.load(f)
+            try:
+                with open(arguments.file) as f:
+                    records = json.load(f)
+            except json.JSONDecodeError:
+                print(
+                    f"Error: '{arguments.file}' is not a valid JSON file. "
+                    "The 'import' command expects a JSON file exported with 'export'. "
+                    "For zone files, use 'import-zone' instead.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             # Create the domain if it does not exist.
             try:
                 api_client.domain_info(arguments.domain)
@@ -831,6 +847,26 @@ def main() -> None:
             print_rrsets(rrsets_result)
 
         elif arguments.action == "import-zone":
+            if not desec.utils.DNSPYTHON_AVAILABLE:
+                print(
+                    "Error: 'import-zone' requires the 'dnspython' package to be installed.\n"
+                    "Install it with: pip install dnspython\n"
+                    "Or if using pipx: pipx inject desec-dns dnspython",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            # Check if the file looks like JSON (common mistake)
+            with open(arguments.file) as f:
+                first_char = f.read(1).strip()
+            if first_char in ("{", "["):
+                print(
+                    f"Error: '{arguments.file}' appears to be a JSON file. "
+                    "The 'import-zone' command expects a zone file (BIND format). "
+                    "For JSON files, use 'import' instead.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
             record_list = desec.parse_zone_file(
                 arguments.file,
                 arguments.domain,

--- a/desec/cli.py
+++ b/desec/cli.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 import typing as t
+import warnings
 from pprint import pprint
 
 import desec
@@ -139,6 +140,19 @@ def main() -> None:
 
     parser.add_argument(
         "--debug-http", action="store_true", help="Print details about http requests / responses."
+    )
+
+    parser.add_argument(
+        "--no-ssl-verify",
+        action="store_true",
+        default=False,
+        help="Disable SSL certificate verification. Use with caution.",
+    )
+
+    parser.add_argument(
+        "--config-file",
+        default=os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"), "desec", "config"),
+        help="Path to the config file (default: $XDG_CONFIG_HOME/desec/config)",
     )
     p = p_action.add_parser("list-tokens", help="list all authentication tokens")
 
@@ -600,15 +614,29 @@ def main() -> None:
     del p_action, g, p, parser
     configure_cli_logging(level=logging.DEBUG if arguments.debug_http else logging.INFO)
 
+    # Load config file if it exists
+    config_file_path = os.path.expanduser(arguments.config_file)
+    config = {}
+    if os.path.exists(config_file_path):
+        with open(config_file_path) as f:
+            config = json.load(f)
+
+    # CLI argument takes precedence over config file
+    no_ssl_verify = arguments.no_ssl_verify or config.get("no-ssl-verify", False)
+
+    # Suppress InsecureRequestWarning when SSL verification is disabled
+    if no_ssl_verify:
+        warnings.filterwarnings("ignore", message=".*Unverified HTTPS request.*")
+
     if arguments.token:
         token = arguments.token
     else:
         with open(os.path.expanduser(arguments.token_file)) as f:
             token = f.readline().strip()
     if arguments.block:
-        api_client = desec.api.APIClient(token)
+        api_client = desec.api.APIClient(token, verify=not no_ssl_verify)
     else:
-        api_client = desec.api.APIClient(token, retry_limit=0)
+        api_client = desec.api.APIClient(token, retry_limit=0, verify=not no_ssl_verify)
     del token
 
     try:


### PR DESCRIPTION
Some, especially corp, networks inject ssl certs via services like zscaler. This makes it possible to use the desec-cli on network like those.
