### PR TITLE
Support getting the API token from a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ provide this token to the CLI:
 In case multiple methods are used simultaneously, priority will be given according to the list
 above in order.
 
+Note: If the token is obtained from a file, the file may be a scripts that
+prints to token to stdout. Scripts are distinguished from plain files by the
+executable permission bit on the file system.
+
 The functionality is split into subcommands, as shown below.
 Most subcommand require further parameters to work.
 They are described by the usage information of each individual subcommand.

--- a/desec/cli.py
+++ b/desec/cli.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import logging
 import os
+import subprocess
 import sys
 import typing as t
 from pprint import pprint
@@ -603,8 +604,15 @@ def main() -> None:
     if arguments.token:
         token = arguments.token
     else:
-        with open(os.path.expanduser(arguments.token_file)) as f:
-            token = f.readline().strip()
+        token_file = os.path.expanduser(arguments.token_file)
+        if os.access(token_file, os.X_OK):
+            proc = subprocess.run(  # noqa: S603
+                token_file, stdout=subprocess.PIPE, text=True, check=True
+            )
+            token = proc.stdout.strip()
+        else:
+            with open(token_file) as f:
+                token = f.readline().strip()
     if arguments.block:
         api_client = desec.api.APIClient(token)
     else:

--- a/man/desec.1
+++ b/man/desec.1
@@ -44,6 +44,9 @@ Mutually exclusive with
 .TP
 .BI \-\-token\-file " TOKEN_FILE"
 File containing the API authentication token.
+The file may also be a script that prints the API authentication token to
+stdout. Scripts are distinguished from plain files by the executable
+permission bit on the file system.
 Defaults to
 .IR $XDG_CONFIG_HOME/desec/token .
 Mutually exclusive with


### PR DESCRIPTION
When obtaining the API token from a file and the file is executable, it gets executed instead of read. It is expected to print the API token (and nothing else) to stdout.
This allows getting the token from a password manager, key ring, database or whatever source by implementing a simple wrapper script.

fix #16